### PR TITLE
Initialize Next.js template with Tailwind and SCSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Next.js + Tailwind CSS + SCSS Template (TypeScript)
+
+This repository contains a minimal setup for a Next.js project configured with Tailwind CSS, SCSS modules, and TypeScript. It includes two example pages: `index` and `second`.
+
+## Available Scripts
+
+- `npm run dev` – start the development server
+- `npm run build` – build the application for production
+- `npm start` – start the production server
+
+## Project Structure
+
+```
+/pages
+  |_ _app.tsx           # Global styles import
+  |_ index.tsx          # Home page
+  |_ second.tsx         # Second page
+/styles
+  |_ globals.scss       # Tailwind directives and global styles
+  |_ Home.module.scss   # Styles for the home page
+  |_ Second.module.scss # Styles for the second page
+```
+
+TailwindCSS directives are placed inside `styles/globals.scss`. Each page imports its own SCSS module for styling.
+
+TypeScript settings are defined in `tsconfig.json` which is included in the project root.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "nextjs-tailwind-scss-template",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "tailwindcss": "^3.4.4",
+    "postcss": "^8.4.24",
+    "autoprefixer": "^10.4.14",
+    "sass": "^1.72.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2",
+    "@types/react": "^18.2.21",
+    "@types/node": "^20.5.9"
+  }
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,6 @@
+import type { AppProps } from 'next/app';
+import '../styles/globals.scss';
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,12 @@
+import type { NextPage } from 'next';
+import styles from '../styles/Home.module.scss';
+
+const Home: NextPage = () => {
+  return (
+    <main className="container mx-auto p-4">
+      <h1 className={styles.title}>Index Page</h1>
+    </main>
+  );
+};
+
+export default Home;

--- a/pages/second.tsx
+++ b/pages/second.tsx
@@ -1,0 +1,12 @@
+import type { NextPage } from 'next';
+import styles from '../styles/Second.module.scss';
+
+const Second: NextPage = () => {
+  return (
+    <main className="container mx-auto p-4">
+      <h1 className={styles.title}>Second Page</h1>
+    </main>
+  );
+};
+
+export default Second;

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/styles/Home.module.scss
+++ b/styles/Home.module.scss
@@ -1,0 +1,3 @@
+.title {
+  @apply text-3xl font-bold text-center text-blue-600;
+}

--- a/styles/Second.module.scss
+++ b/styles/Second.module.scss
@@ -1,0 +1,3 @@
+.title {
+  @apply text-3xl font-semibold text-center text-green-600;
+}

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './pages/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add minimal Next.js project files
- configure Tailwind CSS and SCSS support
- create `index` and `second` pages with SCSS modules
- include a README with instructions
- convert the project to TypeScript

## Testing
- `node -e "console.log('ok')"`

------
https://chatgpt.com/codex/tasks/task_e_688776b9483083308a40fc100df5b18e