### PR TITLE
Integrate Tilda static assets

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,0 +1,60 @@
+import { Html, Head, Main, NextScript } from 'next/document';
+
+export default function Document() {
+  return (
+    <Html>
+      <Head>
+        {/* Tilda CSS assets */}
+        <link rel="stylesheet" href="/tilda/tilda-grid-3.0.min.css" />
+        <link rel="stylesheet" href="/tilda/tilda-blocks-page63732825.min.css" />
+        <link rel="stylesheet" href="/tilda/tilda-blocks-page63785283.min.css" />
+        <link rel="stylesheet" href="/tilda/tilda-blocks-page63790073.min.css" />
+        <link rel="stylesheet" href="/tilda/tilda-animation-2.0.min.css" />
+        <link rel="stylesheet" href="/tilda/tilda-cover-1.0.min.css" />
+        <link rel="stylesheet" href="/tilda/tilda-forms-1.0.min.css" />
+        <link rel="stylesheet" href="/tilda/tilda-slds-1.4.min.css" />
+        <link rel="stylesheet" href="/tilda/tilda-zero-gallery-1.0.min.css" />
+        <link rel="stylesheet" href="/tilda/tilda-zoom-2.0.min.css" />
+        <link rel="stylesheet" href="/tilda/tilda-zero-form-errorbox.min.css" id="t-zero-form-errorbox-styles" />
+        <link rel="stylesheet" href="/tilda/custom.css" />
+        <link rel="stylesheet" href="/tilda/index-inline.css" />
+        <link rel="stylesheet" href="/tilda/training-inline.css" />
+        <link rel="stylesheet" href="/tilda/asia-urope-maraphone-inline.css" />
+      </Head>
+      <body className="t-body" style={{ margin: 0 }}>
+        <Main />
+        <NextScript />
+        {/* Tilda JS assets */}
+        <script src="/tilda/tilda-stat-1.0.min.js.download" async />
+        <script src="/tilda/tilda-fallback-1.0.min.js.download" async charSet="utf-8" />
+        <script src="/tilda/tilda-polyfill-1.0.min.js.download" noModule charSet="utf-8" />
+        <script src="/tilda/jquery-1.10.2.min.js.download" charSet="utf-8" />
+        <script src="/tilda/tilda-scripts-3.0.min.js.download" defer charSet="utf-8" />
+        <script src="/tilda/tilda-blocks-page63732825.min.js.download" async charSet="utf-8" />
+        <script src="/tilda/tilda-blocks-page63785283.min.js.download" async charSet="utf-8" />
+        <script src="/tilda/tilda-blocks-page63790073.min.js.download" async charSet="utf-8" />
+        <script src="/tilda/tilda-lazyload-1.0.min.js.download" async charSet="utf-8" />
+        <script src="/tilda/tilda-animation-2.0.min.js.download" async charSet="utf-8" />
+        <script src="/tilda/tilda-zero-1.1.min.js.download" async charSet="utf-8" />
+        <script src="/tilda/tilda-cover-1.0.min.js.download" async charSet="utf-8" />
+        <script src="/tilda/tilda-menu-1.0.min.js.download" async charSet="utf-8" />
+        <script src="/tilda/tilda-forms-1.0.min.js.download" async charSet="utf-8" />
+        <script src="/tilda/tilda-slds-1.4.min.js.download" async charSet="utf-8" />
+        <script src="/tilda/tilda-zero-gallery-1.0.min.js.download" async charSet="utf-8" />
+        <script src="/tilda/hammer.min.js.download" async charSet="utf-8" />
+        <script src="/tilda/tilda-zero-forms-1.0.min.js.download" async charSet="utf-8" />
+        <script src="/tilda/tilda-animation-sbs-1.0.min.js.download" async charSet="utf-8" />
+        <script src="/tilda/tilda-zero-scale-1.0.min.js.download" async charSet="utf-8" />
+        <script src="/tilda/tilda-zero-fixed-1.0.min.js.download" async charSet="utf-8" />
+        <script src="/tilda/tilda-skiplink-1.0.min.js.download" async charSet="utf-8" />
+        <script src="/tilda/tilda-events-1.0.min.js.download" async charSet="utf-8" />
+        <script src="/tilda/tilda-performance-1.0.min.js.download" async charSet="utf-8" />
+        <script src="/tilda/tilda-phone-mask-1.1.min.js.download" async charSet="utf-8" id="t-zero-phonemask" />
+        <script src="/tilda/tilda-errors-1.0.min.js.download" async />
+        <script src="/tilda/index-inline.js" />
+        <script src="/tilda/training-inline.js" />
+        <script src="/tilda/asia-urope-maraphone-inline.js" />
+      </body>
+    </Html>
+  );
+}


### PR DESCRIPTION
## Summary
- add a custom `_document.tsx` that loads all Tilda CSS and JS so the HTML pages can be moved to TSX

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887a3df7880833095d5800782b7451e