### PR TITLE
feat: add cart state with redux

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@fancyapps/ui": "^6.0.19",
+    "@reduxjs/toolkit": "^2.2.3",
     "animate.css": "^4.1.1",
     "classnames": "^2.5.1",
     "next": "15.4.4",
@@ -17,7 +18,8 @@
     "react-datetime": "^3.3.1",
     "react-dom": "19.1.0",
     "react-hook-form": "^7.62.0",
-    "react-intersection-observer": "^9.16.0"
+    "react-intersection-observer": "^9.16.0",
+    "react-redux": "^9.1.2"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import './styles/globals.scss';
 import Header from '@/components/header/Header';
 import Footer from '@/components/footer/Footer';
+import { Providers } from './providers';
 
 export const metadata: Metadata = {
     title: 'Беговое сообщество - Азия-Европа в Магнитогорске',
@@ -47,11 +48,13 @@ export default function RootLayout({
                 />
             </head>
             <body className="min-w-xs max-w-[2300px] mx-auto">
-                <Header />
+                <Providers>
+                    <Header />
 
-                <main>{children}</main>
+                    <main>{children}</main>
 
-                <Footer />
+                    <Footer />
+                </Providers>
             </body>
         </html>
     );

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import { Provider } from 'react-redux';
+import { store } from '@/store/store';
+
+export function Providers({ children }: { children: React.ReactNode }) {
+    return <Provider store={store}>{children}</Provider>;
+}
+

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -7,9 +7,11 @@ import Link from 'next/link';
 import HamburgerButton from './HamburgerButton';
 import { useEffect, useState } from 'react';
 import MobileMenu from './MobileMenu';
+import { useCart } from '@/store/useCart';
 
 const Header = () => {
     const [menuOpen, setMenuOpen] = useState(false);
+    const { items } = useCart();
 
     useEffect(() => {
         document.body.style.overflow = menuOpen ? 'hidden' : '';
@@ -38,7 +40,9 @@ const Header = () => {
                         <li>Беговая подготовка</li>
                     </Link>
                     <Link href="/shop">
-                        <li>Магазин</li>
+                        <li>
+                            Магазин{items.length ? ` (${items.length})` : ''}
+                        </li>
                     </Link>
                 </ul>
                 <Link

--- a/src/components/shop/ProductBar.tsx
+++ b/src/components/shop/ProductBar.tsx
@@ -3,15 +3,18 @@
 import classNames from 'classnames';
 import { ShopProduct } from './types';
 import { useState } from 'react';
+import { useCart } from '@/store/useCart';
+import type { CartItem } from '@/store/cartSlice';
 
 interface Props {
     product: ShopProduct;
 }
 
-export default function ProductBar({
-    product: { price, discountProcent, description, sizesTitle, sizes },
-}: Props) {
+export default function ProductBar({ product }: Props) {
+    const { price, discountProcent, description, sizesTitle, sizes } =
+        product;
     const [selectedSize, setSelectedSize] = useState<string | null>(null);
+    const { addItem } = useCart();
 
     const finalPrice = discountProcent
         ? Math.ceil((price * (100 - discountProcent)) / 100)
@@ -26,7 +29,16 @@ export default function ProductBar({
         setSelectedSize(size.value);
     };
 
-    const handleAddToCart = () => {};
+    const handleAddToCart = () => {
+        if (!selectedSize) return;
+
+        const item: CartItem = {
+            product,
+            size: selectedSize,
+        };
+
+        addItem(item);
+    };
 
     return (
         <div className="border-1 border-[#EEEEEE] p-8 max-lg:p-4 rounded-lg">

--- a/src/store/cartSlice.ts
+++ b/src/store/cartSlice.ts
@@ -1,0 +1,44 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { ShopProduct } from '@/components/shop/types';
+
+export interface CartItem {
+    product: ShopProduct;
+    size: string;
+}
+
+interface CartState {
+    items: CartItem[];
+}
+
+const initialState: CartState = {
+    items: [],
+};
+
+const cartSlice = createSlice({
+    name: 'cart',
+    initialState,
+    reducers: {
+        addItem(state, action: PayloadAction<CartItem>) {
+            state.items.push(action.payload);
+        },
+        removeItem(
+            state,
+            action: PayloadAction<{ id: string; size: string }>,
+        ) {
+            state.items = state.items.filter(
+                (item) =>
+                    !(
+                        item.product.id === action.payload.id &&
+                        item.size === action.payload.size
+                    ),
+            );
+        },
+        clearCart(state) {
+            state.items = [];
+        },
+    },
+});
+
+export const { addItem, removeItem, clearCart } = cartSlice.actions;
+export default cartSlice.reducer;
+

--- a/src/store/hooks.ts
+++ b/src/store/hooks.ts
@@ -1,0 +1,6 @@
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
+import type { RootState, AppDispatch } from './store';
+
+export const useAppDispatch: () => AppDispatch = useDispatch;
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
+

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,0 +1,12 @@
+import { configureStore } from '@reduxjs/toolkit';
+import cartReducer from './cartSlice';
+
+export const store = configureStore({
+    reducer: {
+        cart: cartReducer,
+    },
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;
+

--- a/src/store/useCart.ts
+++ b/src/store/useCart.ts
@@ -1,0 +1,17 @@
+import { addItem, clearCart, removeItem } from './cartSlice';
+import type { CartItem } from './cartSlice';
+import { useAppDispatch, useAppSelector } from './hooks';
+
+export const useCart = () => {
+    const items = useAppSelector((state) => state.cart.items);
+    const dispatch = useAppDispatch();
+
+    return {
+        items,
+        addItem: (item: CartItem) => dispatch(addItem(item)),
+        removeItem: (id: string, size: string) =>
+            dispatch(removeItem({ id, size })),
+        clearCart: () => dispatch(clearCart()),
+    };
+};
+


### PR DESCRIPTION
## Summary
- add Redux Toolkit store and cart slice with hooks
- wire Redux provider into app layout
- use new cart state in ProductBar and Header

## Testing
- `npm install` (fails: 403 Forbidden)
- `npm run lint` (fails: react/no-unescaped-entities, prefer-const, @typescript-eslint/ban-ts-comment)


------
https://chatgpt.com/codex/tasks/task_e_68934540551c8330a932949da5594634