### PR TITLE
Persist cart items in localStorage

### DIFF
--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,11 +1,35 @@
 import { configureStore } from '@reduxjs/toolkit';
 import cartReducer from './cartSlice';
 
+const loadCart = () => {
+    if (typeof window === 'undefined') return undefined;
+
+    try {
+        const serialized = localStorage.getItem('cart');
+        if (!serialized) return undefined;
+        return { cart: { items: JSON.parse(serialized) } };
+    } catch {
+        return undefined;
+    }
+};
+
 export const store = configureStore({
     reducer: {
         cart: cartReducer,
     },
+    preloadedState: loadCart(),
 });
+
+if (typeof window !== 'undefined') {
+    store.subscribe(() => {
+        const state = store.getState();
+        try {
+            localStorage.setItem('cart', JSON.stringify(state.cart.items));
+        } catch {
+            // ignore write errors
+        }
+    });
+}
 
 export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;


### PR DESCRIPTION
## Summary
- persist cart state in localStorage to survive page reloads

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities, @typescript-eslint/ban-ts-comment, etc.)*
- `npm run build` *(fails: react/no-unescaped-entities, @typescript-eslint/ban-ts-comment, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68936290edcc833082949ca3c26f093a